### PR TITLE
GX-3952: Doppelte Celery Beats aktiv

### DIFF
--- a/docs/design.rst
+++ b/docs/design.rst
@@ -59,7 +59,3 @@ Redbeat use a lock in redis to prevent multiple node running.
 You can safely start multiple nodes as backup, when the running node fails or
 experience network problems, after ``redbeat_lock_timeout`` seconds,
 another node will acquire the lock and start running.
-
-When the previous node back online, it will notice that itself no longer holds
-the lock and exit with an Exception(Would be better if you use systemd or supervisord
-to restart it as a backup node).

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -476,7 +476,7 @@ class RedBeatScheduler(Scheduler):
             except redis.exceptions.LockError:
                 # Lock may no longer be owned due to a suspended process, connection issues, etc.
                 self.lock.token = None
-                logger.debug('beat: Lock no longer owned, re-acquiring...')
+                logger.debug('beat: Lock no longer owned, reacquiring...')
                 self.lock.acquire()
 
         remaining_times = []

--- a/redbeat/schedulers.py
+++ b/redbeat/schedulers.py
@@ -492,9 +492,12 @@ class RedBeatScheduler(Scheduler):
 
     def close(self):
         if self.lock:
-            if self.lock.token:
-                logger.debug('beat: Releasing Lock')
+            logger.debug('beat: Releasing Lock')
+            try:
                 self.lock.release()
+            except redis.exceptions.LockError:
+                # Lock may no longer be owned, in which case a release isn't necessary
+                logger.debug('beat: Lock no longer owned, nothing to release')
             self.lock = None
         super(RedBeatScheduler, self).close()
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,5 +6,5 @@ pytest
 pytest-catchlog
 pytest-cov
 python-dateutil
-redis<3
+redis
 tenacity

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,5 +6,5 @@ pytest
 pytest-catchlog
 pytest-cov
 python-dateutil
-redis
+redis<3
 tenacity

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-celery
+celery<4
 fakeredis>=1.0.3
 mock
 nose
@@ -8,5 +8,3 @@ pytest-cov
 python-dateutil
 redis
 tenacity
-tox
-twine

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -22,7 +22,7 @@ from mock import (
     Mock
 )
 from redis.exceptions import LockError
-from redis.lock import LuaLock
+from redis.lock import Lock
 
 from basecase import RedBeatCase, AppCase
 from redbeat import RedBeatScheduler
@@ -201,7 +201,7 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
         self.assertEqual(self.s.lock_timeout, self.s.max_interval * 5)
 
     def test_lock_reacquisition(self):
-        self.s.lock = Mock(spec=LuaLock)
+        self.s.lock = Mock(spec=Lock)
         self.s.lock.token = '11c6918fc37811eba324309c23a8804c'
         self.s.lock.extend.side_effect = LockError
 
@@ -214,7 +214,7 @@ class test_RedBeatScheduler_tick(RedBeatSchedulerTestBase):
 class test_RedBeatScheduler_close(RedBeatSchedulerTestBase):
 
     def test_release_owned_lock(self):
-        lock = self.s.lock = Mock(spec=LuaLock)
+        lock = self.s.lock = Mock(spec=Lock)
         self.s.lock.token = '11c6918fc37811eba324309c23a8804c'
 
         self.s.close()
@@ -222,7 +222,7 @@ class test_RedBeatScheduler_close(RedBeatSchedulerTestBase):
         assert self.s.lock is None
 
     def test_non_owned_lock(self):
-        lock = self.s.lock = Mock(spec=LuaLock)
+        lock = self.s.lock = Mock(spec=Lock)
         self.s.lock.token = None
 
         self.s.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -215,7 +215,6 @@ class test_RedBeatScheduler_close(RedBeatSchedulerTestBase):
 
     def test_release_owned_lock(self):
         lock = self.s.lock = Mock(spec=Lock)
-        self.s.lock.token = '11c6918fc37811eba324309c23a8804c'
 
         self.s.close()
         lock.release.assert_called_once_with()
@@ -223,10 +222,10 @@ class test_RedBeatScheduler_close(RedBeatSchedulerTestBase):
 
     def test_non_owned_lock(self):
         lock = self.s.lock = Mock(spec=Lock)
-        self.s.lock.token = None
+        lock.release.side_effect = LockError
 
-        self.s.close()
-        lock.release.assert_not_called()
+        self.s.close()  # Should not raise an exception
+        lock.release.assert_called_once_with()
         assert self.s.lock is None
 
 


### PR DESCRIPTION
Wie sich herausgestellt hat, war der RedBeat-Locking-Mechanismus in der von uns eingesetzten Version nicht ganz optimal - es konnten mehrere Beat-Prozesse "denken", dass sie das Lock noch haben, wenn sie es ursprünglich einmal hatten, und dieses auch problemlos weiter verlängern (obwohl es ihnen gar nicht gehörte). Aufmerksam geworden bin ich dadurch insbesondere durch folgendes [Issue](https://github.com/sibson/redbeat/issues/127) im originalen Repo, wo dieser Fall z.B. auftreten konnte, wenn ein Beat-Prozess die Redis-Verbindung verliert, aber nach einer Weile wieder herstellen kann (durchaus auch ein denkbarer Fall bei uns - Timo hatte ja auch regelmäßigen Verbindungsverlust der _Worker_ zum Redis ausfindig gemacht).

Im Rahmen dieses Issues wurde dieses Verhalten dann auch global gefixt - bei jeder Lock-Verlängerung bekommt der Prozess nun mit, wenn ihm das Lock nicht mehr gehört (unabhängig davon, wie diese Situation überhaupt entstanden ist). Diesen Fix wollte ich übernehmen - leider ist er aber erstmals mit RedBeat 2.0.0 wirklich in einer releasten Version enthalten, in der aber auch der Support für Celery < 4.2 gedroppt wurde. Generell eine kurze Versionsübersicht:

0.9.x: Setzen wir aktuell ein und hatten wir offenbar auch schon mal geforkt (obwohl wir unsere eigene Version dann nicht verwendet haben).
0.13.x (2019): Letzte Version der 0-Reihe, die auch Support für unsere Celery-Version enthält und kurz nach deren Release der Fix umgesetzt wurde.
1.0.x (2020): Letzte Version mit Support für unsere Celery-Version, die quasi ein einfaches Re-Release von 0.13 ist mit einer hinzugefügten Warnung, wenn man eine andere Timezone als UTC verwendet. Obwohl die Version nach dem Merge des Fixes erschienen ist, ist dieser hier leider nicht enthalten.
2.0.x (2020): Erste Version mit dem Fix, aber leider inkompatibel mit unserem Celery.

Ich habe mich daher dazu entschieden, den Zustand mit dem Fix, aber vor dem Celery < 4.2 Drop aus der Commit-History als Basis für eine "neue" Version zu verwenden, mit der wir den Fix nutzen können. Diese repräsentiert am ehesten den 0.13-Stand, weswegen ich dafür bei uns einen neuen Branch "0.13.x" angelegt habe (den Branch mit den ganz alten Änderungen von uns habe ich entsprechend in "0.9.x" umbenannt) und die neue Version `0.13.0+rheinwerk1` getauft habe.

Der Fix selbst wurde so umgesetzt, dass nach dem Feststellen, dass einem Prozess das Lock nicht mehr gehört, dieser einfach komplett verendet. Dieses Verhalten habe ich nun so geändert, dass stattdessen eine saubere Reacquisition des Locks stattfindet - daher dieser PR. Mehr dazu dann auch im GX-PR. Echt testen kann man das Verhalten dann ebenfalls dort.

Was ich hier nicht gemacht habe, ist das CI-Setup großartig anzupassen (das originale Repo verwendet mittlerweile GitHub Actions). Zum Testen kann man daher das Ganze einmal ganz traditionell auschecken, eine virtualenv aufsetzen und dort mit pytest testen. Nach dem Merge bitte Bescheid geben, damit ich diese Version auf unserem Prod-Index (manuell) releasen kann.